### PR TITLE
comment out System.Data namespace to avoid errors

### DIFF
--- a/src/DeploymentController.cs
+++ b/src/DeploymentController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/DiscoveryController.cs
+++ b/src/DiscoveryController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/EndingGameController.cs
+++ b/src/EndingGameController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/GameController.cs
+++ b/src/GameController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/GameResources.cs
+++ b/src/GameResources.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/GameState.cs
+++ b/src/GameState.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The GameStates represent the state of the Battleships game play.

--- a/src/HighScoreController.cs
+++ b/src/HighScoreController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using System.IO;
 using SwinGameSDK;

--- a/src/MenuController.cs
+++ b/src/MenuController.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 

--- a/src/Model/AIHardPlayer.cs
+++ b/src/Model/AIHardPlayer.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// AIHardPlayer is a type of player. This AI will know directions of ships

--- a/src/Model/AIMediumPlayer.cs
+++ b/src/Model/AIMediumPlayer.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 
 /// <summary>

--- a/src/Model/AIOption.cs
+++ b/src/Model/AIOption.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The different AI levels.

--- a/src/Model/AIPlayer.cs
+++ b/src/Model/AIPlayer.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 /// <summary>

--- a/src/Model/AttackResult.cs
+++ b/src/Model/AttackResult.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// AttackResult gives the result after a shot has been made.

--- a/src/Model/BattleShipsGame.cs
+++ b/src/Model/BattleShipsGame.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The BattleShipsGame controls a big part of the game. It will add the two players

--- a/src/Model/Direction.cs
+++ b/src/Model/Direction.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The direction the ship can be oriented.

--- a/src/Model/ISeaGrid.cs
+++ b/src/Model/ISeaGrid.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The ISeaGrid defines the read only interface of a Grid. This

--- a/src/Model/Player.cs
+++ b/src/Model/Player.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// Player has its own _PlayerGrid, and can see an _EnemyGrid, it can also check if

--- a/src/Model/ResultOfAttack.cs
+++ b/src/Model/ResultOfAttack.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The result of an attack.

--- a/src/Model/SeaGrid.cs
+++ b/src/Model/SeaGrid.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The SeaGrid is the grid upon which the ships are deployed.

--- a/src/Model/SeaGridAdapter.cs
+++ b/src/Model/SeaGridAdapter.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The SeaGridAdapter allows for the change in a sea grid view. Whenever a ship is

--- a/src/Model/Ship.cs
+++ b/src/Model/Ship.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// A Ship has all the details about itself. For example the shipname,

--- a/src/Model/ShipName.cs
+++ b/src/Model/ShipName.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The names of all of the ships in the gam

--- a/src/Model/Tile.cs
+++ b/src/Model/Tile.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// Tile knows its location on the grid, if it is a ship and if it has been 

--- a/src/Model/TileView.cs
+++ b/src/Model/TileView.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 /// <summary>
 /// The values that are visable for a given tile.

--- a/src/UtilityFunctions.cs
+++ b/src/UtilityFunctions.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+//using System.Data;
 using System.Diagnostics;
 using SwinGameSDK;
 /// <summary>


### PR DESCRIPTION
Each source file had a "using System.Data;" line that was causing errors. This is so we can compile again
